### PR TITLE
Limit dream impressions to Kidoairaku

### DIFF
--- a/src/main/java/com/example/minyumeapp/model/Emotion.java
+++ b/src/main/java/com/example/minyumeapp/model/Emotion.java
@@ -1,10 +1,8 @@
 package com.example.minyumeapp.model;
 
 public enum Emotion {
-    HAPPY,
-    SAD,
-    SCARY,
-    FUNNY,
-    STRANGE,
-    PEACEFUL
+    JOY,
+    ANGER,
+    SORROW,
+    PLEASURE
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -13,12 +13,10 @@
 
         <label>夢の印象：</label>
         <select th:field="*{emotion}">
-            <option th:value="HAPPY">楽しい</option>
-            <option th:value="SAD">悲しい</option>
-            <option th:value="SCARY">怖い</option>
-            <option th:value="FUNNY">おかしい</option>
-            <option th:value="STRANGE">不思議</option>
-            <option th:value="PEACEFUL">穏やか</option>
+            <option th:value="JOY">喜</option>
+            <option th:value="ANGER">怒</option>
+            <option th:value="SORROW">哀</option>
+            <option th:value="PLEASURE">楽</option>
         </select><br><br>
 
         <button type="submit">投稿する</button>


### PR DESCRIPTION
## Summary
- update emotion enum to JOY/ANGER/SORROW/PLEASURE
- reduce dream impression options on index page to 喜怒哀楽

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684145ab9b908320815ec0e17a4d056e