### PR TITLE
Group dreams by emotion

### DIFF
--- a/src/main/java/com/example/minyumeapp/controller/DreamController.java
+++ b/src/main/java/com/example/minyumeapp/controller/DreamController.java
@@ -1,9 +1,13 @@
 package com.example.minyumeapp.controller;
 
 import com.example.minyumeapp.model.Dream;
+import com.example.minyumeapp.model.Emotion;
 import com.example.minyumeapp.service.DreamService;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -37,7 +41,16 @@ public class DreamController {
     @GetMapping("/dreams")
     public String listDreams(Model model) {
         List<Dream> dreams = dreamService.getAllDreams();
-        model.addAttribute("dreams", dreams);
+
+        Map<Emotion, List<Dream>> dreamsByEmotion = new LinkedHashMap<>();
+        for (Emotion emotion : Emotion.values()) {
+            dreamsByEmotion.put(emotion, new ArrayList<>());
+        }
+        for (Dream dream : dreams) {
+            dreamsByEmotion.get(dream.getEmotion()).add(dream);
+        }
+
+        model.addAttribute("dreamsByEmotion", dreamsByEmotion);
         return "dreams"; // → templates/dreams.html を表示
     }
 

--- a/src/main/resources/templates/dreams.html
+++ b/src/main/resources/templates/dreams.html
@@ -7,23 +7,27 @@
 <body>
     <h1>みんなの夢 🌙</h1>
 
-    <ul>
-        <li th:each="dream : ${dreams}">
-            <p>
-                <strong>
-                    <span th:switch="${dream.emotion}">
-                        <span th:case="'JOY'">🙂</span>
-                        <span th:case="'ANGER'">😡</span>
-                        <span th:case="'SORROW'">😭</span>
-                        <span th:case="'PLEASURE'">🤩</span>
-                    </span>
-                </strong> |
-                <span th:text="${#temporals.format(dream.postedAt, 'yyyy-MM-dd HH:mm')}">日時</span><br>
-                <span th:text="${dream.content}">夢の内容</span>
-            </p>
-            <hr>
-        </li>
-    </ul>
+    <div th:each="emotion : ${T(com.example.minyumeapp.model.Emotion).values()}">
+        <div th:if="${#lists.isNotEmpty(dreamsByEmotion[emotion])}">
+            <h2>
+                <span th:switch="${emotion}">
+                    <span th:case="'JOY'">🙂</span>
+                    <span th:case="'ANGER'">😡</span>
+                    <span th:case="'SORROW'">😭</span>
+                    <span th:case="'PLEASURE'">🤩</span>
+                </span>
+            </h2>
+            <ul>
+                <li th:each="dream : ${dreamsByEmotion[emotion]}">
+                    <p>
+                        <span th:text="${#temporals.format(dream.postedAt, 'yyyy-MM-dd HH:mm')}">日時</span><br>
+                        <span th:text="${dream.content}">夢の内容</span>
+                    </p>
+                    <hr>
+                </li>
+            </ul>
+        </div>
+    </div>
 
     <a th:href="@{/}">夢を投稿する</a>
 </body>


### PR DESCRIPTION
## Summary
- group dreams by `Emotion` in controller
- show emoji section headers in the dreams view

## Testing
- `./mvnw -q test` *(fails: Unable to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6844247d6184832095c3be0327cd23e0